### PR TITLE
Make ~/.megalodon as close to a chef repo as possible

### DIFF
--- a/config/run_list.json
+++ b/config/run_list.json
@@ -1,5 +1,5 @@
 {
   "run_list": [
-     "megalodon","megalodon::misc", "role[mega_web_server]", "solr", "varnish", "redis", "mongodb", "php::module_mongo", "phpunit"
+     "role[mega_default]"
   ]
 }

--- a/config/run_list.json
+++ b/config/run_list.json
@@ -1,5 +1,5 @@
 {
   "run_list": [
-     "megalodon","megalodon::misc", "role[web_server]", "solr", "varnish", "redis", "mongodb", "php::module_mongo", "phpunit"
+     "megalodon","megalodon::misc", "role[mega_web_server]", "solr", "varnish", "redis", "mongodb", "php::module_mongo", "phpunit"
   ]
 }

--- a/config/solo.rb
+++ b/config/solo.rb
@@ -10,11 +10,14 @@ file_cache_path    "#{megalodon_root}/cookbooks"
 file_backup_path   "#{megalodon_root}/backup"
 cache_options      ({ :path => "#{megalodon_root}/cache/checksums", :skip_expires => true })
 
-# Optionally store your JSON data file and a tarball of cookbooks remotely.
-#json_attribs "http://chef.example.com/dna.json"
-#recipe_url   "http://chef.example.com/cookbooks.tar.gz"
-cookbook_path File.expand_path(File.join(File.dirname(__FILE__), "..", "cookbooks"))
-role_path     File.expand_path(File.join(File.dirname(__FILE__), "..", "roles"))
+# Load megalodon cookbooks first, then user cookbooks may override.
+cookbook_path [
+  File.expand_path(File.join(File.dirname(__FILE__), "..", "cookbooks")),
+  "#{ENV['HOME']}/.megalodon/cookbooks"
+]
+
+# Load roles and data_bags from user .megalodon directory.
+role_path "#{ENV['HOME']}/.megalodon/roles"
 data_bag_path "#{ENV['HOME']}/.megalodon/data_bags"
 
 Mixlib::Log::Formatter.show_time = false

--- a/megalodon
+++ b/megalodon
@@ -51,9 +51,10 @@ begin
     FileUtils.ln_s(source, target) unless FileTest.exist?(target)
   end
 
+  # Copy default runlist to user node attribs for first run.
   default_run_list = "#{cwd}/config/run_list.json"
   user_node_data = "#{ENV['HOME']}/.megalodon/node.json"
-  FileUtils.cp(default_run_list, user_node_data)
+  FileUtils.cp(default_run_list, user_node_data) unless FileTest.exist?(user_node_data)
 
   mega_vhosts_data = "#{cwd}/config/run_vhosts.json"
   node_attrib = (runlist == 'run_list.json') ? user_node_data : mega_vhosts_data

--- a/megalodon
+++ b/megalodon
@@ -42,14 +42,21 @@ begin
 
   # Clear roles first.
   Dir.glob("#{ENV['HOME']}/.megalodon/roles/mega_*.json") do |role_link|
-    File.delete(role_link)
+    FileUtils.rm(role_link)
   end
 
   # Symlink roles into place.
   Dir.glob("#{cwd}/roles/mega_*.json") do |source|
     target = "#{ENV['HOME']}/.megalodon/roles/#{File.basename(source)}"
-    File.symlink(source, target) unless FileTest.exist?(target)
+    FileUtils.ln_s(source, target) unless FileTest.exist?(target)
   end
+
+  default_run_list = "#{cwd}/config/run_list.json"
+  user_node_data = "#{ENV['HOME']}/.megalodon/node.json"
+  FileUtils.cp(default_run_list, user_node_data)
+
+  mega_vhosts_data = "#{cwd}/config/run_vhosts.json"
+  node_attrib = (runlist == 'run_list.json') ? user_node_data : mega_vhosts_data
 
   solo_path = `which chef-solo`.strip
   unless File.exists?(solo_path)
@@ -59,7 +66,7 @@ begin
   puts "Copying custom forumulas"
   system("cp #{cwd}/formulas/* /usr/local/Library/Formula/")
   puts "Starting chef-solo run"
-  system("#{solo_path} -j #{cwd}/config/#{runlist} -c #{cwd}/config/solo.rb")
+  system("#{solo_path} -j #{node_attrib} -c #{cwd}/config/solo.rb")
 
 rescue LoadError => e
   puts e.message

--- a/megalodon
+++ b/megalodon
@@ -28,21 +28,38 @@ begin
       exit
   end
 
+  cwd = Dir.pwd
+
   # Create the databag directory here since it appears that the chef-solo run
   # will fail if it doesn't already exist. Wish there was a better way to do this…
   directory_name = "#{ENV['HOME']}/.megalodon/data_bags/vhosts"
   FileUtils.mkdir_p(directory_name) unless FileTest::directory?(directory_name)
 
-  cwd = Dir.pwd
-  gem_path = `gem env| grep "EXECUTABLE DIRECTORY"| awk -F': ' '{print $2}'`.strip
-  unless File.exists?("#{gem_path}/chef-solo")
-    raise "Cannot find chef-solo at #{gem_path}/chef-solo}"
+  # Copy "mega" roles to the users .megalodon directory because chef-solo
+  # only supports one roles directory.
+  roles_path = "#{ENV['HOME']}/.megalodon/roles"
+  FileUtils.mkdir_p(roles_path) unless FileTest::directory?(roles_path)
+
+  # Clear roles first.
+  Dir.glob("#{ENV['HOME']}/.megalodon/roles/mega_*.json") do |role_link|
+    File.delete(role_link)
+  end
+
+  # Symlink roles into place.
+  Dir.glob("#{cwd}/roles/mega_*.json") do |source|
+    target = "#{ENV['HOME']}/.megalodon/roles/#{File.basename(source)}"
+    File.symlink(source, target) unless FileTest.exist?(target)
+  end
+
+  solo_path = `which chef-solo`.strip
+  unless File.exists?(solo_path)
+    raise "Cannot find chef-solo at #{solo_path}}"
   end
 
   puts "Copying custom forumulas"
   system("cp #{cwd}/formulas/* /usr/local/Library/Formula/")
   puts "Starting chef-solo run"
-  system("#{gem_path}/chef-solo -j #{cwd}/config/#{runlist} -c #{cwd}/config/solo.rb")
+  system("#{solo_path} -j #{cwd}/config/#{runlist} -c #{cwd}/config/solo.rb")
 
 rescue LoadError => e
   puts e.message

--- a/roles/mega_default.json
+++ b/roles/mega_default.json
@@ -1,0 +1,21 @@
+{
+  "name": "mega_default",
+  "default_attributes": {
+  },
+  "json_class": "Chef::Role",
+  "run_list": [
+    "recipe[megalodon]",
+    "recipe[megalodon::misc]",
+    "role[mega_web_server]",
+    "recipe[solr]",
+    "recipe[varnish]",
+    "recipe[redis]",
+    "recipe[mongodb]",
+    "recipe[php::module_mongo]",
+    "recipe[phpunit]"
+  ],
+  "description": "",
+  "chef_type": "role",
+  "override_attributes": {
+  }
+}

--- a/roles/mega_nginx_web_server.json
+++ b/roles/mega_nginx_web_server.json
@@ -1,16 +1,20 @@
 {
-  "name": "web_server",
+  "name": "mega_nginx_web_server",
   "default_attributes": {
   },
   "json_class": "Chef::Role",
+  "default": {
+  },
+  "override": {
+  },
   "run_list": [
+    "recipe[nginx]",
     "recipe[mysql::mariadb]",
-    "recipe[php]",
+    "recipe[php::fpm]",
     "recipe[php::module_apc]",
     "recipe[php::module_memcached]",
     "recipe[php::module_xdebug]",
-    "recipe[xhprof]",
-    "recipe[megalodon::apache_vhosts]"
+    "recipe[xhprof]"
   ],
   "description": "",
   "chef_type": "role",

--- a/roles/mega_web_server.json
+++ b/roles/mega_web_server.json
@@ -1,20 +1,16 @@
 {
-  "name": "nginx_web_server",
+  "name": "mega_web_server",
   "default_attributes": {
   },
   "json_class": "Chef::Role",
-  "default": {
-  },
-  "override": {
-  },
   "run_list": [
-    "recipe[nginx]",
     "recipe[mysql::mariadb]",
-    "recipe[php::fpm]",
+    "recipe[php]",
     "recipe[php::module_apc]",
     "recipe[php::module_memcached]",
     "recipe[php::module_xdebug]",
-    "recipe[xhprof]"
+    "recipe[xhprof]",
+    "recipe[megalodon::apache_vhosts]"
   ],
   "description": "",
   "chef_type": "role",


### PR DESCRIPTION
As #14 points out, Megalodon can't be all things to all people.  We should encourage people to use `~/.megalodon` for customization and extension beyond the core goals.  Check it into VCS and share it!

`cookbooks` is easy as chef-solo already takes an array for `cookbook_path`, latter directory's cookbooks override former of the same name.

`data_bags` are only read from ` ~/.megalodon`, so they don't need override.

`roles` appears to be one directory only for chef-solo.  Vagrant compiles them in a shared directory, we could probably do some similar magic with symlinks.

Overrides for `run_list` would be nice.